### PR TITLE
Implement Continue Listening Widget with Resume Playback Functionality

### DIFF
--- a/lib/audio_player_screen.dart
+++ b/lib/audio_player_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'controller/continue_listening_controller.dart';
+
+class AudioPlayerScreen extends StatelessWidget {
+  const AudioPlayerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(ContinueListeningController());
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+
+            Expanded(
+              child: Center(
+                child: Text(
+                  'Empty Area',
+                  style: TextStyle(fontSize: 20, color: Colors.grey),
+                ),
+              ),
+            ),
+
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 24),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+                boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 6)],
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.replay_30, size: 36),
+                    onPressed: controller.rewind30Seconds,
+                  ),
+
+                  Obx(() => IconButton(
+                    icon: Icon(
+                      controller.isPlaying.value ? Icons.pause_circle : Icons.play_circle,
+                      size: 48,
+                      color: Colors.green,
+                    ),
+                    onPressed: () {
+                      controller.isPlaying.value
+                          ? controller.pauseAndSavePosition()
+                          : controller.playFromLastPosition();
+                    },
+                  )),
+
+                  IconButton(
+                    icon: const Icon(Icons.forward_30, size: 36),
+                    onPressed: controller.forward30Seconds,
+                  ),
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/book.dart
+++ b/lib/book.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:min_dia/listener_page.dart';
+import 'package:min_dia/widget/listen_widget.dart';
+
+import 'audio_player_screen.dart';
 
 class BookPage extends StatelessWidget {
   const BookPage({super.key});
@@ -8,40 +11,50 @@ class BookPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Book')),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            GestureDetector(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const PodcastListenerWidget(),
+      body: Stack(
+        children: [
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                GestureDetector(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) =>  AudioPlayerScreen(),
+                      ),
+                    );
+                  },
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.audiotrack, size: 150, color: Colors.blue),
+                      const SizedBox(height: 20),
+                      const Text(
+                        'Listen to Book',
+                        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                      ),
+                    ],
                   ),
-                );
-              },
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.audiotrack, size: 150, color: Colors.blue),
-                  const SizedBox(height: 20),
-                  const Text(
-                    'Listen to Book',
-                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                  ),
-                ],
-              ),
+                ),
+                const SizedBox(height: 20),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text('Go Back'),
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              child: const Text('Go Back'),
-            ),
-          ],
-        ),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: ContinueListeningWidget(),
+          )
+        ],
       ),
     );
   }

--- a/lib/controller/continue_listening_controller.dart
+++ b/lib/controller/continue_listening_controller.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:just_audio/just_audio.dart';
+
+class ContinueListeningController extends GetxController with WidgetsBindingObserver {
+  final box = GetStorage();
+  final player = AudioPlayer();
+
+  var isPlaying = false.obs;
+  var isVisible = true.obs;
+
+  var lastPosition = Duration.zero.obs;
+  var totalDuration = const Duration(seconds: 1).obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    WidgetsBinding.instance.addObserver(this);
+    loadSavedPosition();
+    box.listen(() {
+      print("nowwwwwww");
+    },);
+  }
+
+  @override
+  void onClose() {
+    saveCurrentPosition();
+    player.dispose();
+    WidgetsBinding.instance.removeObserver(this);
+    super.onClose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
+      stopAndSavePosition();
+    }
+  }
+
+  void loadSavedPosition() {
+    final seconds = box.read('last_position') ?? 0;
+    final totalSeconds = box.read('total_duration') ?? 1;
+    lastPosition.value = Duration(seconds: seconds);
+    totalDuration.value = Duration(seconds: totalSeconds);
+  }
+
+  Future<void> playFromLastPosition() async {
+    try {
+      loadSavedPosition();
+      isPlaying.value = false;
+      await player.setUrl('http://daq7nasbr6dck.cloudfront.net/7habits/1.mp3');
+
+      await player.durationStream.firstWhere((d) => d != null);
+      await player.seek(lastPosition.value);
+
+      isPlaying.value = true;
+      await player.play();
+    } catch (e) {
+      print("Play error: $e");
+    }
+  }
+
+  Future<void> pauseAndSavePosition() async {
+    await player.pause();
+    isPlaying.value = false;
+    saveCurrentPosition();
+  }
+
+  Future<void> stopAndSavePosition() async {
+    await player.stop();
+    isPlaying.value = false;
+    saveCurrentPosition();
+  }
+
+  Future<void> saveCurrentPosition() async {
+    final curr = player.position;
+    final dur = player.duration ?? const Duration(seconds: 1);
+    double percent = (curr.inSeconds / dur.inSeconds) * 100;
+    percent = percent.clamp(0.0, 100.0);
+    print('percentageListened: $percent');
+    print('currInSeconds: ${curr.inSeconds}');
+
+    if (percent > 94) {
+      box.write('last_position', 0); // reset
+    } else {
+      box.write('last_position', curr.inSeconds);
+    }
+
+    box.write('total_duration', dur.inSeconds);
+  }
+
+  Future<void> rewind30Seconds() async {
+    final newPosition = player.position - const Duration(seconds: 30);
+    await player.seek(newPosition >= Duration.zero ? newPosition : Duration.zero);
+  }
+
+  Future<void> forward30Seconds() async {
+    final newPosition = player.position + const Duration(seconds: 30);
+    final duration = player.duration ?? const Duration(seconds: 1);
+    if (newPosition < duration) {
+      await player.seek(newPosition);
+    } else {
+      await player.seek(duration);
+    }
+  }
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:min_dia/widget/listen_widget.dart';
 import 'book.dart';
 
 class HomePage extends StatelessWidget {
@@ -8,26 +9,34 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Podcast Reader')),
-      body: Center(
-        child: GestureDetector(
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => const BookPage()),
-            );
-          },
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(Icons.book, size: 150, color: Colors.blue),
-              const SizedBox(height: 20),
-              const Text(
-                'Open Book',
-                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      body: Stack(
+        children: [
+          Center(
+            child: GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const BookPage()),
+                );
+              },
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.book, size: 150, color: Colors.blue),
+                  const SizedBox(height: 20),
+                  const Text('Open Book',
+                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
+           Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: ContinueListeningWidget(),
+          )
+        ],
       ),
     );
   }

--- a/lib/listener_page.dart
+++ b/lib/listener_page.dart
@@ -31,8 +31,7 @@ class _PodcastListenerWidgetState extends State<PodcastListenerWidget>
     _audioUrl = AudioSource.uri(
       Uri.parse('http://daq7nasbr6dck.cloudfront.net/7habits/1.mp3'),
       tag: MediaItem(
-        // Specify required metadata
-        id: '1', // Unique ID for this media item
+        id: '1',
         album: '7 Habits of Highly Effective People',
         title: 'Chapter 1',
         artist: 'Stephen R. Covey',
@@ -43,7 +42,6 @@ class _PodcastListenerWidgetState extends State<PodcastListenerWidget>
     );
     _player = AudioPlayer(
       audioLoadConfiguration: AudioLoadConfiguration(
-        // iOS/macOS settings
         darwinLoadControl: DarwinLoadControl(
           automaticallyWaitsToMinimizeStalling:
               false, // Start playback immediately
@@ -220,11 +218,7 @@ class _PodcastListenerWidgetState extends State<PodcastListenerWidget>
               100.0,
             )
             : 0.0;
-    // logInteractionInServer(
-    //   widget.book.id,
-    //   widget.chapterIndex,
-    //   percentageListened.toInt(),
-    // );
+
     print('percentageListened: $percentageListened');
     if (percentageListened > 94) {
       _currentPosition = Duration.zero;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,62 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:get_storage/get_storage.dart';
 import 'package:min_dia/home.dart';
 
-void main() {
+void main() async {
+  await GetStorage.init();
   runApp(const MyApp());
 }
-
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(child: HomePage());
+    return MaterialApp(home: HomePage(),debugShowCheckedModeBanner: false,);
   }
 }

--- a/lib/widget/listen_widget.dart
+++ b/lib/widget/listen_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controller/continue_listening_controller.dart';
+
+class ContinueListeningWidget extends StatelessWidget {
+  ContinueListeningWidget({super.key});
+  final controller = Get.put(ContinueListeningController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      if (!controller.isVisible.value) return const SizedBox.shrink();
+
+      return Container(
+        margin: const EdgeInsets.all(10),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.greenAccent.shade100,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [BoxShadow(blurRadius: 4, color: Colors.black12)],
+        ),
+        child: Row(
+          children: [
+            Image.network(
+              'http://daq7nasbr6dck.cloudfront.net/7habits/cover.jpg',
+              height: 50,
+              width: 50,
+            ),
+            const SizedBox(width: 12),
+            const Expanded(
+              child: Text(
+                'The Subtle Art of Not Giving a F*ck',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+              ),
+            ),
+            Obx(() => IconButton(
+              icon: Icon(controller.isPlaying.value ? Icons.pause : Icons.play_arrow),
+              onPressed: () async {
+                if (controller.isPlaying.value) {
+                  await controller.pauseAndSavePosition(); // Save on pause
+                } else {
+                  await controller.playFromLastPosition(); // Resume from saved
+                }
+              },
+            )),
+          ],
+        ),
+      );
+    });
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   audio_service:
     dependency: transitive
     description:
@@ -69,34 +69,34 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.19.0"
   crypto:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "0c6396126421b590089447154c5f98a5de423b70cfb15b1578fd018843ee6f53"
+      sha256: "72d146c6d7098689ff5c5f66bcf593ac11efc530095385356e131070333e64da"
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "11.3.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -312,6 +312,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get:
+    dependency: "direct main"
+    description:
+      name: get
+      sha256: c79eeb4339f1f3deffd9ec912f8a923834bec55f7b49c9e882b8fef2c139d425
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.2"
+  get_storage:
+    dependency: "direct main"
+    description:
+      name: get_storage
+      sha256: "39db1fffe779d0c22b3a744376e86febe4ade43bf65e06eab5af707dc84185a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   google_fonts:
     dependency: "direct main"
     description:
@@ -356,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.1"
   just_audio:
     dependency: "direct main"
     description:
@@ -396,18 +412,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -428,10 +444,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -444,18 +460,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -564,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -665,10 +681,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sprintf:
     dependency: transitive
     description:
@@ -681,34 +697,34 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.4+6"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
@@ -721,50 +737,50 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.0+3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -881,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -897,18 +913,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.10.1"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "1.1.5"
   xdg_directories:
     dependency: transitive
     description:
@@ -926,5 +942,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.7.0
+  sdk: ">=3.6.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -44,9 +44,11 @@ dependencies:
   flutter_timezone: ^4.1.0
   firebase_messaging: ^15.2.5
   permission_handler: ^11.3.1
-  device_info_plus: ^11.4.0
+  device_info_plus: ^11.3.0
   app_settings: ^6.1.1
   in_app_review: ^2.0.10
+  get:
+  get_storage: ^2.1.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This PR adds the Continue Listening widget to the Home Page and Book Page of the min-dia app, allowing users to resume playback from where they left off without navigating to the Audio Page.

✅ Features Implemented:

* Continue Listening Widget
    - Appears on both Home and Book pages.
    - Visible only if audio has previously been played.

* Playback Resumption
    - Clicking the play button resumes audio from the last listened position.
    - Playback happens inline (no redirection to Audio Page).

* State Persistence
    - Stores last listened position using persistent storage.

* Event Handling
    - _handleDisposeEvent correctly fires and logs listening percentage when:
        - App is closed
        - Navigated to Audio Page
        - Widget is dismissed

![WhatsApp Image 2025-06-08 at 18 51 10_e5fcaa35](https://github.com/user-attachments/assets/69a1b502-4d53-44c8-8e13-826111435411)